### PR TITLE
Moved sleep inside of GUI, graceful exit when X clicked

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -93,8 +93,9 @@ window.Layout(layout)
 cap = cv.VideoCapture(0)
 
 while True:
-    time.sleep(0.25)
-    button, values = window.ReadNonBlocking()
+    button, values = window.ReadNonBlocking(timeout=250)
+    if button is None:
+        break
 
     ret, frame = cap.read()
 
@@ -119,6 +120,6 @@ while True:
     window.FindElement('flirPreview').Update(data=imgbytes2)
 
     # process button presses:
-    if button:
+    if button != sg.TIMEOUT_KEY:
         #sg.Popup(values['loadProfileButton'])
         sg.Popup(values)


### PR DESCRIPTION
What an incredible bit of UI work you've done!  I like it!

What I don't like is the ReadNonBlocking call.  I'm going to be removing that function shortly.  Instead of a sleep with a read-non-block, try doing a Read with a timeout.  This will cause the exact same "sleep" within your loop.  The difference is that your GUI will remain 100% responsive during this time.  It's the best of both worlds, a responsive GUI and an accurate time 

Very nicely done.  I learned several new things from your code. 
