### PR TITLE
Ooops... It should be Read!

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -93,7 +93,7 @@ window.Layout(layout)
 cap = cv.VideoCapture(0)
 
 while True:
-    button, values = window.ReadNonBlocking(timeout=250)
+    button, values = window.Read(timeout=250)
     if button is None:
         break
 


### PR DESCRIPTION
Wow, I really blew that one.  Should have been Read not ReadNonBlocking.
